### PR TITLE
Fix h2o serializable

### DIFF
--- a/src/ml/h2o/H2ODeepLearningClassifier.java
+++ b/src/ml/h2o/H2ODeepLearningClassifier.java
@@ -82,11 +82,11 @@ public class H2ODeepLearningClassifier implements estimator,classifier {
 	/**
 	 * Parameter for internal use to allow the system to print in the console
 	 */
-	private PrintStream originalStream = System.out;
+	private transient PrintStream originalStream = System.out;
 	/**
 	 * Parameter for internal use to block the system to print in the console
 	 */
-	private PrintStream dummyStream  = new PrintStream(new OutputStream(){
+	private transient PrintStream dummyStream  = new PrintStream(new OutputStream(){
 	    public void write(int b) {}
 		});
 	/**
@@ -150,7 +150,7 @@ public class H2ODeepLearningClassifier implements estimator,classifier {
 	 */
 	public double rate=0.1;	
 	/**
-	 * Learning rate annealing reduces the learning rate to “freeze” into local minima in the optimization landscape
+	 * Learning rate annealing reduces the learning rate to ï¿½freezeï¿½ into local minima in the optimization landscape
 	 */
 	public double rate_annealing=1e-6 ;	
 	/**

--- a/src/ml/h2o/H2ODeepLearningClassifier.java
+++ b/src/ml/h2o/H2ODeepLearningClassifier.java
@@ -150,7 +150,7 @@ public class H2ODeepLearningClassifier implements estimator,classifier {
 	 */
 	public double rate=0.1;	
 	/**
-	 * Learning rate annealing reduces the learning rate to �freeze� into local minima in the optimization landscape
+	 * Learning rate annealing reduces the learning rate to "freeze" into local minima in the optimization landscape
 	 */
 	public double rate_annealing=1e-6 ;	
 	/**

--- a/src/ml/h2o/H2ODeepLearningRegressor.java
+++ b/src/ml/h2o/H2ODeepLearningRegressor.java
@@ -85,11 +85,11 @@ public class H2ODeepLearningRegressor implements estimator,regressor {
 	/**
 	 * Parameter for internal use to allow the system to print in the console
 	 */
-	private PrintStream originalStream = System.out;
+	private transient PrintStream originalStream = System.out;
 	/**
 	 * Parameter for internal use to block the system to print in the console
 	 */
-	private PrintStream dummyStream  = new PrintStream(new OutputStream(){
+	private transient PrintStream dummyStream  = new PrintStream(new OutputStream(){
 	    public void write(int b) {}
 		});
 	
@@ -170,7 +170,7 @@ public class H2ODeepLearningRegressor implements estimator,regressor {
 	 */
 	public double rate=0.1;	
 	/**
-	 * Learning rate annealing reduces the learning rate to “freeze” into local minima in the optimization landscape
+	 * Learning rate annealing reduces the learning rate to ï¿½freezeï¿½ into local minima in the optimization landscape
 	 */
 	public double rate_annealing=1e-6 ;	
 	/**

--- a/src/ml/h2o/H2ODeepLearningRegressor.java
+++ b/src/ml/h2o/H2ODeepLearningRegressor.java
@@ -170,7 +170,7 @@ public class H2ODeepLearningRegressor implements estimator,regressor {
 	 */
 	public double rate=0.1;	
 	/**
-	 * Learning rate annealing reduces the learning rate to �freeze� into local minima in the optimization landscape
+	 * Learning rate annealing reduces the learning rate to "freeze" into local minima in the optimization landscape
 	 */
 	public double rate_annealing=1e-6 ;	
 	/**

--- a/src/ml/h2o/H2ODrfClassifier.java
+++ b/src/ml/h2o/H2ODrfClassifier.java
@@ -77,11 +77,11 @@ public class H2ODrfClassifier implements estimator,classifier {
 	/**
 	 * Parameter for internal use to allow the system to print in the console
 	 */
-	private PrintStream originalStream = System.out;
+	private transient PrintStream originalStream = System.out;
 	/**
 	 * Parameter for internal use to block the system to print in the console
 	 */
-	private PrintStream dummyStream  = new PrintStream(new OutputStream(){
+	private transient PrintStream dummyStream  = new PrintStream(new OutputStream(){
 	    public void write(int b) {}
 		});
 

--- a/src/ml/h2o/H2ODrfRegressor.java
+++ b/src/ml/h2o/H2ODrfRegressor.java
@@ -72,11 +72,11 @@ public class H2ODrfRegressor implements estimator,regressor {
 	/**
 	 * Parameter for internal use to allow the system to print in the console
 	 */
-	private PrintStream originalStream = System.out;
+	private transient PrintStream originalStream = System.out;
 	/**
 	 * Parameter for internal use to block the system to print in the console
 	 */
-	private PrintStream dummyStream  = new PrintStream(new OutputStream(){
+	private transient PrintStream dummyStream  = new PrintStream(new OutputStream(){
 	    public void write(int b) {}
 		});
 	/**

--- a/src/ml/h2o/H2OGbmClassifier.java
+++ b/src/ml/h2o/H2OGbmClassifier.java
@@ -80,11 +80,11 @@ public class H2OGbmClassifier implements estimator,classifier {
 	/**
 	 * Parameter for internal use to allow the system to print in the console
 	 */
-	private PrintStream originalStream = System.out;
+	private transient PrintStream originalStream = System.out;
 	/**
 	 * Parameter for internal use to block the system to print in the console
 	 */
-	private PrintStream dummyStream  = new PrintStream(new OutputStream(){
+	private transient PrintStream dummyStream  = new PrintStream(new OutputStream(){
 	    public void write(int b) {}
 		});
 

--- a/src/ml/h2o/H2OGbmRegressor.java
+++ b/src/ml/h2o/H2OGbmRegressor.java
@@ -75,11 +75,11 @@ public class H2OGbmRegressor implements estimator,regressor {
 	/**
 	 * Parameter for internal use to allow the system to print in the console
 	 */
-	private PrintStream originalStream = System.out;
+	private transient PrintStream originalStream = System.out;
 	/**
 	 * Parameter for internal use to block the system to print in the console
 	 */
-	private PrintStream dummyStream  = new PrintStream(new OutputStream(){
+	private transient PrintStream dummyStream  = new PrintStream(new OutputStream(){
 	    public void write(int b) {}
 		});
 	/**

--- a/src/ml/h2o/H2OGlmClassifier.java
+++ b/src/ml/h2o/H2OGlmClassifier.java
@@ -82,11 +82,11 @@ public class H2OGlmClassifier implements estimator,classifier {
 	/**
 	 * Parameter for internal use to allow the system to print in the console
 	 */
-	private PrintStream originalStream = System.out;
+	private transient PrintStream originalStream = System.out;
 	/**
 	 * Parameter for internal use to block the system to print in the console
 	 */
-	private PrintStream dummyStream  = new PrintStream(new OutputStream(){
+	private transient PrintStream dummyStream  = new PrintStream(new OutputStream(){
 	    public void write(int b) {}
 		});
 

--- a/src/ml/h2o/H2OGlmRegressor.java
+++ b/src/ml/h2o/H2OGlmRegressor.java
@@ -84,11 +84,11 @@ public class H2OGlmRegressor implements estimator,regressor {
 	/**
 	 * Parameter for internal use to allow the system to print in the console
 	 */
-	private PrintStream originalStream = System.out;
+	private transient PrintStream originalStream = System.out;
 	/**
 	 * Parameter for internal use to block the system to print in the console
 	 */
-	private PrintStream dummyStream  = new PrintStream(new OutputStream(){
+	private transient PrintStream dummyStream  = new PrintStream(new OutputStream(){
 	    public void write(int b) {}
 		});
 	/**

--- a/src/ml/h2o/H2ONaiveBayesClassifier.java
+++ b/src/ml/h2o/H2ONaiveBayesClassifier.java
@@ -79,11 +79,11 @@ public class H2ONaiveBayesClassifier implements estimator,classifier {
 	/**
 	 * Parameter for internal use to allow the system to print in the console
 	 */
-	private PrintStream originalStream = System.out;
+	private transient PrintStream originalStream = System.out;
 	/**
 	 * Parameter for internal use to block the system to print in the console
 	 */
-	private PrintStream dummyStream  = new PrintStream(new OutputStream(){
+	private transient PrintStream dummyStream  = new PrintStream(new OutputStream(){
 	    public void write(int b) {}
 		});
 


### PR DESCRIPTION
Marked non-serializable fields as transient to avoid:
IOException:  at 
`Serialized_Object.save(model_file, (Serializable) stacknetreg)`

P.S.
My IDE auto-replaced "left and right curved double quotation marks" with regular "quotation marks" in Java comment.
I hope that this is not a problem.